### PR TITLE
docs: refresh README and CONTENT for docker dev and build pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,20 +4,26 @@ DW嚴選公開站使用 Nuxt SSG 與 Nuxt Content。商品資料放在 `content/
 
 ## Local development
 
-開發環境跑在 Docker 容器，透過 Traefik 自動路由到 `https://${APP_URL}/`（預設 `dwselect.toybox.local`）。環境設定放在未提交的 `.env`（參考 `.env.example`），`APP_URL` 為必填。
+分工：**測試與檢查跑在 host，dev server 跑在 Docker 容器**。
 
-啟動與管理開發站：
+安裝 host 依賴（跑測試、lint、typecheck、build artifacts 用）：
+
+```bash
+pnpm install
+```
+
+啟動與管理 dev server（Docker 容器透過 Traefik 自動路由到 `https://${APP_URL}/`，預設 `dwselect.toybox.local`；環境設定放在未提交的 `.env`，參考 `.env.example`，`APP_URL` 為必填）：
 
 ```bash
 ./dev.sh start      # 啟動容器（NUXT_MODE=dev 跑含 HMR 的 dev server）
-./dev.sh install    # 容器內 pnpm install，同步 package.json 變更
+./dev.sh install    # package.json 變更後同步容器內依賴
 ./dev.sh logs       # 看 Nuxt log
 ./dev.sh status     # 看容器狀態
 ```
 
 不要直接在 host 上跑 `pnpm dev`——會與容器共用 Vite cache 造成 chunk hash 衝突。指令細節見 `CLAUDE.md`。
 
-執行測試與檢查（`vitest.config.ts` 已載入 `.env`，不需手動帶 `APP_URL=` 前綴）：
+執行測試與檢查（host，`vitest.config.ts` 已載入 `.env`，不需手動帶 `APP_URL=` 前綴）：
 
 ```bash
 pnpm test

--- a/README.md
+++ b/README.md
@@ -4,31 +4,35 @@ DW嚴選公開站使用 Nuxt SSG 與 Nuxt Content。商品資料放在 `content/
 
 ## Local development
 
-安裝 dependencies：
+開發環境跑在 Docker 容器，透過 Traefik 自動路由到 `https://${APP_URL}/`（預設 `dwselect.toybox.local`）。環境設定放在未提交的 `.env`（參考 `.env.example`），`APP_URL` 為必填。
+
+啟動與管理開發站：
 
 ```bash
-pnpm install
+./dev.sh start      # 啟動容器（NUXT_MODE=dev 跑含 HMR 的 dev server）
+./dev.sh install    # 容器內 pnpm install，同步 package.json 變更
+./dev.sh logs       # 看 Nuxt log
+./dev.sh status     # 看容器狀態
 ```
 
-啟動本機開發伺服器：
+不要直接在 host 上跑 `pnpm dev`——會與容器共用 Vite cache 造成 chunk hash 衝突。指令細節見 `CLAUDE.md`。
 
-```bash
-pnpm dev
-```
-
-執行測試：
+執行測試與檢查（`vitest.config.ts` 已載入 `.env`，不需手動帶 `APP_URL=` 前綴）：
 
 ```bash
 pnpm test
+pnpm lint
+pnpm typecheck
 ```
 
-產生 public search index：
+產生公開站 build artifacts：
 
 ```bash
-pnpm build:search-index
+pnpm build:public-artifacts   # search index → public/search-index.json、discovery payload → public/api/content.json
+pnpm build:content-images     # 本地化 content 圖片
 ```
 
-搜尋 index 會輸出到 `public/search-index.json`。`pnpm generate` 會先執行這個步驟，確保靜態輸出使用最新 Git-backed content。
+`pnpm generate` 與 `pnpm build` 會先跑 `build:content-images` 與 `build:public-artifacts`，確保靜態輸出使用最新 Git-backed content；單獨的 `build:search-index`、`build:public-discovery` 仍保留為個別 CLI。
 
 ## Migration
 

--- a/docs/CONTENT.md
+++ b/docs/CONTENT.md
@@ -69,4 +69,4 @@ pnpm build:search-index
 pnpm build:public-discovery
 ```
 
-`pnpm generate` 會先執行 `pnpm build:content-images`、`pnpm build:search-index` 與 `pnpm build:public-discovery`，再產生 static output 到 `.output/public`。交付前若有內容、圖片、taxonomy、routing 或 public output 相關變更，應執行 `pnpm test`、`pnpm generate`，並用 `node scripts/assert-runtime-google-sheet-clean.ts` 確認公開 runtime 沒有 Google Sheets 指標。
+`pnpm generate` 會先執行 `pnpm build:content-images` 與 `pnpm build:public-artifacts`（後者單次讀取 content source 後同時產生 search index 與 public discovery payload），再產生 static output 到 `.output/public`。交付前若有內容、圖片、taxonomy、routing 或 public output 相關變更，應執行 `pnpm test`、`pnpm generate`，並用 `node scripts/assert-runtime-google-sheet-clean.ts` 確認公開 runtime 沒有 Google Sheets 指標。

--- a/tests/nuxt-smoke.test.ts
+++ b/tests/nuxt-smoke.test.ts
@@ -640,7 +640,7 @@ describe('Nuxt SSG baseline', () => {
   it('should document static search-index generation commands', () => {
     const readme_source = readFileSync(new URL('../README.md', import.meta.url), 'utf8')
 
-    expect(readme_source).toContain('pnpm build:search-index')
+    expect(readme_source).toContain('pnpm build:public-artifacts')
     expect(readme_source).toContain('public/search-index.json')
     expect(readme_source).toContain('pnpm generate')
   })


### PR DESCRIPTION
## 摘要

更新兩份過期文件，對齊 008.7 docker dev sprint 與 020 build pipeline 的現況。

- **README.md**
  - Local development 改用 Docker `./dev.sh` workflow，取代會與容器搶 Vite cache 的 host `pnpm dev`
  - 補上 `.env` / `APP_URL`（必填）說明
  - 修正 build artifact 指令：`build:public-artifacts`（含 `public/api/content.json`），不再用舊的 `build:search-index` 單步描述
  - 測試指令標明已不需手動帶 `APP_URL=` 前綴
- **docs/CONTENT.md**
  - `pnpm generate` 改跑 `build:public-artifacts`（單次 source read 同時產 search index 與 discovery payload），取代舊的分開兩步描述

Migration、Production deploy 與各 sprint 的 spec/works 經查證仍為現況或屬歷史記錄，未更動。

## 測試

純文件變更，無 production code。

🤖 Generated with [Claude Code](https://claude.com/claude-code)